### PR TITLE
Adding Online with Auth and Custom Cloud BigPeer Endpoint

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -122,7 +122,6 @@ class _DittoExampleState extends State<DittoExample> {
       body: Column(
         children: [
           _portalInfo,
-          _syncTile,
           const Divider(height: 1),
           Expanded(child: _tasksList),
         ],
@@ -161,25 +160,6 @@ class _DittoExampleState extends State<DittoExample> {
           style: TextStyle(fontSize: 12),
         ),
       ]);
-
-
-  Widget get _syncTile => SwitchListTile(
-        title: const Text("Syncing"),
-        value: _syncing,
-        onChanged: (value) async {
-          if (value) {
-            print("starting sync");
-            await _ditto!.startSync();
-            print(await _ditto!.isSyncActive);
-          } else {
-            print("stopping sync");
-            await _ditto!.stopSync();
-            print(await _ditto!.isSyncActive);
-            print(_ditto!.isActivated);
-          }
-          setState(() => _syncing = value);
-        },
-      );
 
   Widget get _tasksList => DqlBuilder(
         ditto: _ditto!,


### PR DESCRIPTION
This PR adds the following two capabilities:

1. Online with Authentication using a custom webhook
2. Custom Cloud Big Peer Endpoint

###  Online with Authentication
Online with authentication hits a custom webhook called `replit-auth` using the `manager01` token.

The token object is generic and defined in the webhook handler. Customer implementing real authentication should replace the token with a securely crafted application token.

### Custom Cloud Big Peer Endpoint
To add the custom Big Peer endpoint there are two urls that needing updating.

*Updating the identity endpoint.* In this example below we are hitting the `cloud-dev` endpoint which is a Ditto internal dev endpoint. You can get this endpoint by working with your Ditto Customer Experience engineer.
```dart
final identity = await OnlineWithAuthenticationIdentity.create(
      appID: appID,
      authenticationHandler: authenticationHandler,
      customAuthUrl: "https://$appID.cloud-dev.ditto.live" // Custom Big Peer endpoint
      );
```

*Updating the websocket endpoint*. This endpoint represents the websocket endpoint that Ditto will be syncing data over. This is done by adding a websocket endpoint to a custom transport config.

```dart
    // Using a custom transport config to specify the websocket endpoint of a custom Big Peer Endpoint
    final peerToPeer = PeerToPeer.all();
    final connect = Connect(webSocketUrls: {"wss://$appID.cloud-dev.ditto.live"});
    final transportConfig = TransportConfig(peerToPeer: peerToPeer, connect: connect);
    ditto.setTransportConfig(transportConfig);
```




