### PR TITLE
Adding SDK Logging

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -49,6 +49,20 @@ class _DittoExampleState extends State<DittoExample> {
     final persistenceDirectory = Directory("${dataDir.path}/ditto");
     await persistenceDirectory.create(recursive: true);
 
+    // Setup the Ditto Logger
+    DittoLogger.setMinimumLogLevel(LogLevel.debug);
+    DittoLogger.setEnabled(true);
+    DittoLogger.setCustomLogCallback((logLevel, logString) {
+      print("$logLevel: $logString");
+
+      if (logLevel == LogLevel.error || logLevel == LogLevel.warning) {
+        // if it's an error or a warning we'll dump all the logs to a new path
+        DittoLogger.exportLogs('$dataDir/ditto_log_dump/$logLevel-${DateTime.now().toIso8601String()}');
+      }
+    });
+
+
+
     final ditto = await Ditto.open(
       identity: identity,
       persistenceDirectory: persistenceDirectory,


### PR DESCRIPTION
Example of adding Logging to the SDK

- Enables Logging
- Set's the LogLevel to debug
- Prints all logs to console
- Does a log dump to file if an error or warning occurs