### PR TITLE
⬆️ Gradle (8.5)

### DIFF
--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -31,11 +31,3 @@ plugins {
 
 rootProject.name = 'exampleApp'
 include ":app"
-
-//def dittoAndroidSdk = file("../../../../android")
-//includeBuild(dittoAndroidSdk) {
-//    name = "dittoAndroidSdk"
-//    dependencySubstitution {
-//        substitute module('live.ditto:ditto') using project(':ditto')
-//    }
-//}


### PR DESCRIPTION
I upgraded the gradle wrapper to `8.5`. This version of gradle contains an embedded copy of Kotlin `1.9.20`. This aligns the version of Kotlin with the version used in the kotlin gradle plugin and kotlin stdlib dependency.

```
❯ ./gradlew --version

------------------------------------------------------------
Gradle 8.5
------------------------------------------------------------

Build time:   2023-11-29 14:08:57 UTC
Revision:     28aca86a7180baa17117e0e5ba01d8ea9feca598

Kotlin:       1.9.20
Groovy:       3.0.17
Ant:          Apache Ant(TM) version 1.10.13 compiled on January 4 2023
JVM:          17.0.12 (JetBrains s.r.o. 17.0.12+1-b1207.37)
OS:           Mac OS X 15.2 aarch64
```